### PR TITLE
Added process name instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ to
 
 You might need to add other services to this list if your Rails application requires them.
 
+Depending on your ruby package, you may need to change procname. This is used to match the process name to the pid, to determine whether Puma is running. If you installed ruby 2.4 on FreeBSD, you would change
+
+    # procname="ruby"
+    
+to
+
+    # procname="ruby24"
+
 
 ## Quick Setup
 


### PR DESCRIPTION
Ran into an issue on my system (FreeBSD 12, ruby installed via `pkg install`) where my ruby proc name is `ruby24` instead of `ruby`, which was resulting in `service puma status` always saying that puma wasn't running, even when it was. This is just a little readme enhancement to give others a heads-up.